### PR TITLE
Expanded ROM block handling

### DIFF
--- a/docs/readme.html
+++ b/docs/readme.html
@@ -149,6 +149,15 @@
                     The level window is where level editing takes place. You can click any element on the board (apart from blocks and constellation graphics), move it around and change its properties. You can also insert new elements from the element picker.
                 </p>
 
+                <p>The order of precedence for the different layers and elements depend on whether the ROM has been expanded or not, but the editor will adapt to the actual case. Rendering order, from first drawn to last, is as follows:</p>
+
+                <ul>
+                    <li>Vanilla ROM: blocks, door, key, mirrors, items, meta tiles</li>
+                    <li>Expanded ROM: mirrors, blocks, items, door, key, meta tiles</li>
+                </ul>
+
+                <p>Editor Controls:</p>
+
                 <ul>
                     <li><b>Right Click</b>: Will insert the selected element picker element at the location, unless one exists there already. If you want to place more than one enemy at the same location - make one in a free location and move it.</li>
                     <li><b>Left Click</b>: Select item on the gameboard. Will change element mode to the type of the selected element. (if you are in items editing mode and click on a metadata item, the editing mode will change to metadata) The selected element will be outlined by a pulsating yellow square</li>
@@ -352,7 +361,11 @@
 
                 <p>When loading a base US-version of the ROM, the editor gives you the option of expanding the ROM. When the ROM is expanded, the data section sizes are greatly increased. Each Demon Mirror gets its own drop schedule and enemy set (with up to 7 enemies in each), the levels can have arbitrarily many items, and each level can have up to 15 enemies.</p>
 
-                <p>When converting a base ROM to an expanded ROM, a patch is applied. This patch changes the mapper from number 3 to 66, and alters some gamecode to read data from other locations. There are some fundamental differences in the way the data is stored in an original ROM versus an expanded ROM. An overview of the expanded ROM data layout follows.</p>
+                <p>When converting a base ROM to an expanded ROM, a patch is applied. This patch changes the mapper from number 3 to 66, and alters some gamecode to read data from other locations. There are some fundamental differences in the way the data is stored in an original ROM versus an expanded ROM.</p>
+
+                <p>In an expanded ROM, the level data is stored as a grid of items - and the in-game rendering order of layers and elements is different.</p>
+
+                <p>An overview of the expanded ROM data layout follows.</p>
 
                 <p>The level data starts at offset 0xc010, and comes in 53 contiguous blocks of 256 bytes - one block per level. The following table describes the layout of such a block:</p>
 

--- a/readme.md
+++ b/readme.md
@@ -47,10 +47,11 @@ The [ROM map document](./docs/solomon's_key_rom_map.md) contains all information
 
 ### Upcoming Changes in v1.1
 
+* The rendering order of layers and elements depend on whether the ROM has been expanded or not. The editor should now correctly reflect the actual output in either case
 * Support for clearing all level data for a given level, to quickly provide a "blank canvas" for editing
 * Support for giving ROM region code as a command-line parameter, to override the automatic region deduction
 * The Demon Mirror Enemy Set editor interfaces will use the tileset of the currently loaded level when presenting the enemy graphics
 * Foreground rendering can be toggled on/off per layer (metadata, items and enemies)
 * Associate all items and enemies (including glitchy elements) with graphics and descriptions
 * Added a new section in the readme; technical documentation of the data layout of expanded ROMs
-* ...and probably more.
+

--- a/skchain/source/skc_constants/Constants_application.h
+++ b/skchain/source/skc_constants/Constants_application.h
@@ -9,6 +9,7 @@ namespace skc {
 		constexpr char APP_VERSION[]{ "1.1-snapshot" };
 		constexpr char APP_TITLE[]{ "Solomon's Keychain v1.1-snapshot" };
 		constexpr int APP_W{ 1024 + 435 }, APP_H{ 768 };
+		constexpr char EDITOR_SIGNATURE[]{ "kaimitai@github " };
 
 		constexpr char FILENAME_CONFIG_XML[]{ "skc_config.xml" };
 		constexpr char FILENAME_ERROR_LOG[]{ "skc_errors.log" };

--- a/skchain/source/skc_constants/Constants_application.h
+++ b/skchain/source/skc_constants/Constants_application.h
@@ -74,6 +74,8 @@ namespace skc {
 		constexpr char REGION_EU[]{ "EU" };
 		constexpr char REGION_JP[]{ "JP" };
 		constexpr char REGION_US[]{ "US" };
+		// virtual region US66 - indicating expanded US ROM
+		constexpr char REGION_US66[]{ "US66" };
 	}
 }
 

--- a/skchain/source/skc_util/Rom_expander.cpp
+++ b/skchain/source/skc_util/Rom_expander.cpp
@@ -315,6 +315,16 @@ bool skc::m66::is_rom_expanded(std::size_t p_mirror_schedule_count) {
 std::vector<byte> skc::m66::cleanup_skedit_rom(const std::vector<byte>& p_rom66_data) {
 	std::vector<byte> result{ p_rom66_data };
 
+	std::string l_rom_signature{ c::EDITOR_SIGNATURE };
+	auto iter{ begin(l_rom_signature) };
+
+	const auto get_next_char = [&iter, &l_rom_signature](void) -> char {
+		char result{ *(iter++) };
+		if (iter == end(l_rom_signature))
+			iter = begin(l_rom_signature);
+		return result;
+	};
+
 	for (std::size_t i{ 0 }; i < c::COUNT_M66_LEVELS; ++i) {
 		// clean the 4 or 5 unused bytes at the end of the metadata stream
 		std::size_t l_offset{ c::OFFSET_M66_LVL_DATA + c::LENGTH_M66_LVL_DATA * i };
@@ -330,7 +340,7 @@ std::vector<byte> skc::m66::cleanup_skedit_rom(const std::vector<byte>& p_rom66_
 		std::size_t j{ 1 };
 		for (; p_rom66_data.at(l_offset + c::OFFSET_M66_LOCAL_ENEMY_DATA + j) != 0; ++j);
 		for (std::size_t k{ j + 1 }; k < c::LENGTH_M66_ENEMY_DATA; ++k)
-			result.at(l_offset + c::OFFSET_M66_LOCAL_ENEMY_DATA + k) = 0;
+			result.at(l_offset + c::OFFSET_M66_LOCAL_ENEMY_DATA + k) = get_next_char();
 
 		// clean the end of the enemy set data sections
 		j = 0;
@@ -338,15 +348,14 @@ std::vector<byte> skc::m66::cleanup_skedit_rom(const std::vector<byte>& p_rom66_
 			c::MIRROR_ENEMY_SET_DELIMITER;
 			++j);
 		for (std::size_t k{ j + 1 }; k < c::LENGTH_M66_ENEMY_SET_DATA; ++k)
-			result.at(l_offset + c::OFFSET_M66_LOCAL_SCHED_ENEMY_1_DATA + k) = 0;
+			result.at(l_offset + c::OFFSET_M66_LOCAL_SCHED_ENEMY_1_DATA + k) = get_next_char();
 
 		j = 0;
 		for (; p_rom66_data.at(l_offset + c::OFFSET_M66_LOCAL_SCHED_ENEMY_2_DATA + j) !=
 			c::MIRROR_ENEMY_SET_DELIMITER;
 			++j);
 		for (std::size_t k{ j + 1 }; k < c::LENGTH_M66_ENEMY_SET_DATA; ++k)
-			result.at(l_offset + c::OFFSET_M66_LOCAL_SCHED_ENEMY_2_DATA + k) = 0;
-
+			result.at(l_offset + c::OFFSET_M66_LOCAL_SCHED_ENEMY_2_DATA + k) = get_next_char();
 	}
 
 	return result;

--- a/skchain/source/skc_util/Rom_expander.cpp
+++ b/skchain/source/skc_util/Rom_expander.cpp
@@ -339,7 +339,8 @@ bool skc::m66::is_mirror_visible(const skc::Level& p_level, std::size_t p_mirror
 		for (const auto& l_item : p_level.get_items())
 			if (l_pos == l_item.get_position() && l_item.get_element_no() != c::ITEM_NO_DEMON_MIRROR)
 				return false;
-		return true;
+		bool l_res{ p_level.get_wall_type(l_pos.first, l_pos.second) == skc::Wall::None };
+		return l_res;
 	}
 	else
 		return false;

--- a/skchain/source/skc_util/Rom_expander.h
+++ b/skchain/source/skc_util/Rom_expander.h
@@ -77,6 +77,7 @@ namespace skc {
 			const std::vector<std::vector<bool>>& p_drop_scheds,
 			const std::vector<skc::Level>& p_levels
 		);
+		void remove_blocks_behind_demon_mirrors(std::vector<skc::Level>& p_levels);
 		bool is_rom_expanded(std::size_t p_mirror_schedule_count);
 		std::vector<byte> cleanup_skedit_rom(const std::vector<byte>& p_rom66_data);
 

--- a/skchain/source/skc_windows/SKC_Main_window.cpp
+++ b/skchain/source/skc_windows/SKC_Main_window.cpp
@@ -858,3 +858,20 @@ bool skc::SKC_Main_window::is_rom_expanded(void) const {
 void skc::SKC_Main_window::set_application_icon(SDL_Window* p_window) const {
 	m_gfx.set_application_icon(p_window);
 }
+
+// procedure that will change the current level data into an expanded version of the same data
+void skc::SKC_Main_window::expand_rom_data(SKC_Config& p_config) {
+	m_drop_enemies = m66::expand_enemy_sets(m_drop_enemies, m_levels);
+	m_drop_schedules = m66::expand_drop_schedules(m_drop_schedules, m_levels);
+
+	for (std::size_t i{ 0 }; i < m_levels.size(); ++i) {
+		m_levels[i].set_spawn_enemies(0, static_cast<byte>(2 * i));
+		m_levels[i].set_spawn_enemies(1, static_cast<byte>(2 * i + 1));
+		m_levels[i].set_spawn_schedule(0, static_cast<byte>(2 * i));
+		m_levels[i].set_spawn_schedule(1, static_cast<byte>(2 * i + 1));
+	}
+
+	m66::remove_blocks_behind_demon_mirrors(m_levels);
+
+	p_config.add_message("Expanded ROM size and gave Demon Mirrors separate data", c::MSG_CODE_SUCCESS);
+}

--- a/skchain/source/skc_windows/SKC_Main_window.cpp
+++ b/skchain/source/skc_windows/SKC_Main_window.cpp
@@ -616,6 +616,12 @@ std::vector<byte> skc::SKC_Main_window::generate_patch_bytes_rom03(SKC_Config& p
 		l_output.at(p_config.get_offset_enemy_table_lo() + i) = l_ram_address.second;
 	}
 
+	// apply signature
+	std::string l_signature{ c::EDITOR_SIGNATURE };
+	if (l_item_data.size() + l_signature.size() <= p_config.get_length_item_data()) {
+		l_item_data.insert(end(l_item_data), begin(l_signature), end(l_signature));
+	}
+
 	// patch item data
 	for (std::size_t i{ 0 }; i < l_item_data.size(); ++i)
 		l_output.at(p_config.get_offset_item_data() + i) = l_item_data[i];

--- a/skchain/source/skc_windows/SKC_Main_window.h
+++ b/skchain/source/skc_windows/SKC_Main_window.h
@@ -46,6 +46,10 @@ namespace skc {
 		int get_tile_w(int p_screen_h) const;
 		void draw_tile(SDL_Renderer* p_rnd, SDL_Texture* p_texture, int p_x, int p_y, bool p_transp = false) const;
 		void generate_texture(SDL_Renderer* p_rnd, const SKC_Config& p_config);
+		void generate_texture_mirrors(SDL_Renderer* p_rnd, const SKC_Config& p_config,
+			const skc::Level& p_level, std::size_t p_tileset_no);
+		void generate_texture_blocks(SDL_Renderer* p_rnd, const SKC_Config& p_config,
+			const skc::Level& p_level, std::size_t p_tileset_no);
 
 		// ui stuff
 		void draw_ui(SKC_Config& p_config, const klib::User_input& p_input);
@@ -91,6 +95,7 @@ namespace skc {
 		position get_metadata_tile_position(byte p_board_index_no) const;
 		void set_metadata_tile_position(byte p_board_index_no, const position& p_pos, const SKC_Config& p_config);
 		void toggle_render_all(void);
+		bool is_rom_expanded(void) const;
 
 		// file
 		std::vector<byte> generate_patch_bytes(SKC_Config& p_config) const;

--- a/skchain/source/skc_windows/SKC_Main_window.h
+++ b/skchain/source/skc_windows/SKC_Main_window.h
@@ -46,9 +46,16 @@ namespace skc {
 		int get_tile_w(int p_screen_h) const;
 		void draw_tile(SDL_Renderer* p_rnd, SDL_Texture* p_texture, int p_x, int p_y, bool p_transp = false) const;
 		void generate_texture(SDL_Renderer* p_rnd, const SKC_Config& p_config);
+		
 		void generate_texture_mirrors(SDL_Renderer* p_rnd, const SKC_Config& p_config,
 			const skc::Level& p_level, std::size_t p_tileset_no);
 		void generate_texture_blocks(SDL_Renderer* p_rnd, const SKC_Config& p_config,
+			const skc::Level& p_level, std::size_t p_tileset_no);
+		void generate_texture_door_and_key(SDL_Renderer* p_rnd, const SKC_Config& p_config,
+			const skc::Level& p_level, std::size_t p_tileset_no);
+		void generate_texture_meta_tiles(SDL_Renderer* p_rnd, const SKC_Config& p_config,
+			const skc::Level& p_level, std::size_t p_tileset_no);
+		void generate_texture_items(SDL_Renderer* p_rnd, const SKC_Config& p_config,
 			const skc::Level& p_level, std::size_t p_tileset_no);
 
 		// ui stuff

--- a/skchain/source/skc_windows/SKC_Main_window.h
+++ b/skchain/source/skc_windows/SKC_Main_window.h
@@ -96,6 +96,7 @@ namespace skc {
 		void set_metadata_tile_position(byte p_board_index_no, const position& p_pos, const SKC_Config& p_config);
 		void toggle_render_all(void);
 		bool is_rom_expanded(void) const;
+		void expand_rom_data(SKC_Config& p_config);
 
 		// file
 		std::vector<byte> generate_patch_bytes(SKC_Config& p_config) const;

--- a/skchain/source/skc_windows/SKC_Main_window_file.cpp
+++ b/skchain/source/skc_windows/SKC_Main_window_file.cpp
@@ -1,5 +1,6 @@
 #include "SKC_Main_window.h"
 #include "./../skc_util/Xml_helper.h"
+#include "./../skc_util/Rom_expander.h"
 #include "./../common/klib/klib_file.h"
 #include "./../common/klib/klib_util.h"
 #include "./../common/klib/IPS_Patch.h"
@@ -73,6 +74,7 @@ void skc::SKC_Main_window::load_xml_files(SKC_Config& p_config) {
 							mkvt.second = kv.second;
 			}
 		}
+
 		p_config.add_message("Metadata xml file loaded", c::MSG_CODE_SUCCESS);
 	}
 	catch (const std::exception& ex) {
@@ -92,4 +94,7 @@ void skc::SKC_Main_window::load_xml_files(SKC_Config& p_config) {
 	}
 	p_config.add_message(std::to_string(l_import_count) + " level xml files loaded from " + p_config.get_xml_path(),
 		l_import_count == p_config.get_level_count() ? c::MSG_CODE_SUCCESS : c::MSG_CODE_WARNING);
+
+	if (p_config.get_region_code() == c::REGION_US66 && !is_rom_expanded())
+		expand_rom_data(p_config);
 }

--- a/skchain/source/skc_windows/SKC_Main_window_ui.cpp
+++ b/skchain/source/skc_windows/SKC_Main_window_ui.cpp
@@ -150,21 +150,10 @@ void skc::SKC_Main_window::draw_ui_main_window(SKC_Config& p_config, const klib:
 		save_nes_file(p_config, p_input.is_shift_pressed());
 
 	if (p_config.get_region_code() == c::REGION_US &&
-		!m66::is_rom_expanded(m_drop_enemies.size())) {
+		!is_rom_expanded()) {
 		ImGui::SameLine();
-		if (imgui::button("Expand ROM", 1, "Change ROM mapper. Holdt Ctrl to use") && l_ctrl) {
-			m_drop_enemies = m66::expand_enemy_sets(m_drop_enemies, m_levels);
-			m_drop_schedules = m66::expand_drop_schedules(m_drop_schedules, m_levels);
-
-			for (std::size_t i{ 0 }; i < m_levels.size(); ++i) {
-				m_levels[i].set_spawn_enemies(0, static_cast<byte>(2 * i));
-				m_levels[i].set_spawn_enemies(1, static_cast<byte>(2 * i + 1));
-				m_levels[i].set_spawn_schedule(0, static_cast<byte>(2 * i));
-				m_levels[i].set_spawn_schedule(1, static_cast<byte>(2 * i + 1));
-			}
-
-			p_config.add_message("Expanded ROM size and gave Demon Mirrors separate data", c::MSG_CODE_SUCCESS);
-		}
+		if (imgui::button("Expand ROM", 1, "Change ROM mapper. Holdt Ctrl to use") && l_ctrl)
+			expand_rom_data(p_config);
 	}
 
 	if (imgui::button("Load xml", c::COLOR_STYLE_NORMAL, "Hold ctrl to use this button")


### PR DESCRIPTION
The editor will now differentiate rendering order based on whether the ROM is expanded or not, and this is reflected in the order in which the game data is written to patch bytes